### PR TITLE
add support for absolute paths

### DIFF
--- a/lua/cmp_pandoc/parse.lua
+++ b/lua/cmp_pandoc/parse.lua
@@ -152,6 +152,10 @@ end
 M.bibliography = function(bufnr, opts)
   local bib_paths = M.get_bibliography_paths(bufnr)
 
+  if vim.g["pandoc#biblio#bibs"] then
+    bib_paths = vim.g["pandoc#biblio#bibs"]
+  end
+
   if not bib_paths then
     return
   end

--- a/lua/cmp_pandoc/parse.lua
+++ b/lua/cmp_pandoc/parse.lua
@@ -108,7 +108,12 @@ M.get_bibliography_paths = function(bufnr)
 end
 
 local read_file = function(path)
-  local p = Path.new(vim.api.nvim_buf_get_name(0)):parent():joinpath(path):absolute()
+  local p = path
+  -- resolve relative path
+  if not path:sub(1,1) == '/' then
+    p = Path.new(vim.api.nvim_buf_get_name(0)):parent():joinpath(path):absolute()
+  end
+
   if Path:new(p):exists() then
     local file = io.open(p, "rb")
     local results = file:read("*all")


### PR DESCRIPTION
Just added a check to see if a bibliography path starts with '/', and, if so, to treat it as an absolute path.