### PR TITLE
Add label sanity check to entry formatting

### DIFF
--- a/lua/cmp_pandoc/utils.lua
+++ b/lua/cmp_pandoc/utils.lua
@@ -46,6 +46,7 @@ M.format = function(str, field)
 end
 
 M.format_entry = function(opts)
+  if not opts.label then return nil end
   local label_prefix = opts.prefix or "@"
   local kind = cmp.lsp.CompletionItemKind[opts.kind] or cmp.lsp.CompletionItemKind.Reference
   local doc = opts.doc or true


### PR DESCRIPTION
Fixes #5.

Before returning a formatted entry check if the current entry options
carry a label. If they don't they are probably not an entry that should
be displayed since we don't know how to in the completion menu.
Instead they are in all probability for example a metadata entry
provided through JabRef.