### PR TITLE
Adds support for divs

### DIFF
--- a/lua/cmp_pandoc/parse.lua
+++ b/lua/cmp_pandoc/parse.lua
@@ -181,17 +181,15 @@ local crossreferences = function(line, opts)
   end
 
   if string.match(line, utils.crossref_patterns.div_html) then
-    local caption = string.match(line, [[._-caption=['"]([^\r]+)["'].->]]) or ""
     return utils.format_entry({
-      label = string.match(line,  utils.crossref_patterns.div_html),
-      value = "*" .. vim.trim(caption) .. "*",
+      label = string.match(line, utils.crossref_patterns.div_html),
+      value = "*" .. vim.trim(string.match(line, [[._-caption=['"]([^\r]+)["'].->]]) or "") .. "*",
     })
   end
   print(line)
 
   if string.match(line, utils.crossref_patterns.equation) and string.match(line, "^%$%$(.*)%$%$") then
     local equation = string.match(line, "^%$%$(.*)%$%$")
-
     return utils.format_entry({
       label = string.match(line, utils.crossref_patterns.equation),
       doc = opts.documentation,
@@ -202,28 +200,28 @@ local crossreferences = function(line, opts)
   if string.match(line, utils.crossref_patterns.section) and string.match(line, "^#%s+(.*){") then
     return utils.format_entry({
       label = string.match(line, utils.crossref_patterns.section),
-      value = "*" .. vim.trim(string.match(line, "#%s+(.*){")) .. "*",
+      value = "*" .. vim.trim(string.match(line, "#%s+(.*){") or "") .. "*",
     })
   end
 
   if string.match(line, utils.crossref_patterns.table) then
     return utils.format_entry({
       label = string.match(line, utils.crossref_patterns.base),
-      value = "*" .. vim.trim(string.match(line, "^:%s+(.*)%s+{")) .. "*",
+      value = "*" .. vim.trim(string.match(line, "^:%s+(.*)%s+{") or "") .. "*",
     })
   end
 
   if string.match(line, utils.crossref_patterns.lst) then
     return utils.format_entry({
       label = string.match(line, utils.crossref_patterns.lst),
-      value = "*" .. vim.trim(string.match(line, "^:%s+(.*)%s+{")) .. "*",
+      value = "*" .. vim.trim(string.match(line, "^:%s+(.*)%s+{") or "") .. "*",
     })
   end
 
   if string.match(line, utils.crossref_patterns.figure) then
     return utils.format_entry({
       label = string.match(line, utils.crossref_patterns.figure),
-      value = "*" .. vim.trim(string.match(line, "^%!%[.*%]%((.*)%)")) .. "*",
+      value = "*" .. vim.trim(string.match(line, "^%!%[.*%]%((.*)%)") or "") .. "*",
     })
   end
 end

--- a/lua/cmp_pandoc/utils.lua
+++ b/lua/cmp_pandoc/utils.lua
@@ -25,7 +25,7 @@ local crossref_patterns = {
   figure = "{#(fig:[%w_-]+)",
   table = "{#(tbl:[%w_-]+)",
   lst = "{#(lst:[%w_-]+)",
-  div_fence = ":::%s*%{#([%w_-]+:[%w_-]+)",
+  div_fence = "::+%s*%{#([%w_-]+:[%w_-]+)",
   div_ticks = "```%s*%{#([%w_-]+:[%w_-]+)",
   div_html = [[<%s*div.-id=["']([%w_-]+:[%w_-]+)]]
 }

--- a/lua/cmp_pandoc/utils.lua
+++ b/lua/cmp_pandoc/utils.lua
@@ -19,11 +19,15 @@ local template = {
 
 local crossref_patterns = {
   base = "{#(%a+:[%w_-]+)",
+  base_div = "<%s*div.->",
   equation = "{#(eq:[%w_-]+)",
   section = "{#(sec:[%w_-]+)",
   figure = "{#(fig:[%w_-]+)",
   table = "{#(tbl:[%w_-]+)",
   lst = "{#(lst:[%w_-]+)",
+  div_fence = ":::%s*%{#([%w_-]+:[%w_-]+)",
+  div_ticks = "```%s*%{#([%w_-]+:[%w_-]+)",
+  div_html = [[<%s*div.-id=["']([%w_-]+:[%w_-]+)]]
 }
 
 M.crossref_patterns = crossref_patterns


### PR DESCRIPTION
Will print the name and the caption if present on the same line.

This adds cmp completion for these cases from pandoc-crossref

```{.md}
<div id="fig:figureRef" class="subfigures">

![a](image1.png){#fig:figureRefA}

![b](image2.png){#fig:figureRefB}

Figure 1: Caption of figure. a — subfigure 1 caption, b — subfigure 2
caption

</div>

::::: {#fig:figureComp}
![a](image1.png){#fig:figureCompA}
![b](image2.png){#fig:figureCompB}

Caption
:::::


\`\`\`{#lst:code .haskell caption="Listing caption"}
main :: IO ()
main = putStrLn "Hello World!"
\`\`\`


```

This PR also catches an error when value is empty inside vim.trim. It used to happened with these fenced divs for example. If not in this list of divs, no error will be raised but no cmp suggestion as well.